### PR TITLE
Fix typing error for email subject

### DIFF
--- a/src/emailconstructor/email_constructor.py
+++ b/src/emailconstructor/email_constructor.py
@@ -371,7 +371,9 @@ class EmailConstructor:
         email["From"] = self._sender_address
         email["To"] = ";".join(self.primary_recipients)
         email["Cc"] = ";".join(self.cc_recipients)
-        email["Subject"] = self.subject
+
+        if self.subject is not None:
+            email["Subject"] = self.subject
 
         email.attach(MIMEText(self.body, "html"))
 


### PR DESCRIPTION
Prevents None values from being assigned to the email subject per `MIMEMultipart` typing.